### PR TITLE
chore: console.logを構造化ロガーに置換 (Refs #39)

### DIFF
--- a/src/components/agritech/EntryLayout.astro
+++ b/src/components/agritech/EntryLayout.astro
@@ -80,6 +80,10 @@ const entryDescription =
   </style>
 
   <script>
+    import { createLogger } from "@lib/logger";
+
+    const log = createLogger("agritech.EntryLayout");
+
     // Process link card placeholders on the client side - Enhanced version with API fallback
     document.addEventListener('DOMContentLoaded', async () => {
       const placeholders = document.querySelectorAll('.link-card-placeholder');
@@ -133,7 +137,9 @@ const entryDescription =
             return createLinkCardHTML(data.url, data.title || hostname, data.description || '', data.image || '', data.siteName || hostname);
           }
         } catch (error) {
-          console.log('Firebase Function not available, using offline fallback:', (error as Error).message);
+          log.warn('Firebase Function not available, using offline fallback', {
+            error: (error as Error).message,
+          });
         }
 
         // Offline fallback with enhanced site recognition

--- a/src/lib/firebaseLoader.ts
+++ b/src/lib/firebaseLoader.ts
@@ -1,6 +1,9 @@
 import { initializeApp, getApp, getApps } from "firebase/app";
 import { getDatabase, ref, get } from "firebase/database";
 import type { BlogEntry } from "@/types";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("firebaseLoader");
 
 // Firebase Client SDK初期化関数（PUBLIC_変数を使用）
 function initializeFirebase() {
@@ -27,19 +30,19 @@ function initializeFirebase() {
         "1:293681935404:web:188089a29ff3da05490d89",
     };
 
-    console.log("🔧 Firebase Client initialization...");
-    console.log(
-      "Project ID:",
-      import.meta.env.PUBLIC_FIREBASE_PROJECT_ID || "agricultural-llc",
-    );
-    console.log(
-      "Database URL:",
-      import.meta.env.PUBLIC_FIREBASE_DATABASE_URL ||
+    log.debug("Firebase Client initialization started");
+    log.debug("Firebase project configured", {
+      projectId:
+        import.meta.env.PUBLIC_FIREBASE_PROJECT_ID || "agricultural-llc",
+    });
+    log.debug("Firebase database configured", {
+      databaseURL:
+        import.meta.env.PUBLIC_FIREBASE_DATABASE_URL ||
         "https://agricultural-llc-default-rtdb.asia-southeast1.firebasedatabase.app",
-    );
+    });
 
     initializeApp(firebaseConfig);
-    console.log("✅ Firebase Client initialized");
+    log.info("Firebase Client initialized");
   }
 
   const app = getApp();
@@ -68,21 +71,19 @@ export interface FirebaseBlogEntry {
 // Firebaseから記事を取得
 export async function getFirebaseBlogEntries(): Promise<BlogEntry[]> {
   try {
-    console.log("🔍 Fetching blog entries from Firebase...");
+    log.info("Fetching blog entries from Firebase");
     const db = initializeFirebase();
     const snapshot = await get(ref(db, "cms/blog"));
 
     if (!snapshot.exists()) {
-      console.log("❌ No blog data found in Firebase");
+      log.info("No blog data found in Firebase");
       return [];
     }
 
     const data = snapshot.val();
-    console.log(
-      "📊 Raw Firebase data:",
-      Object.keys(data).length,
-      "entries found",
-    );
+    log.info("Raw Firebase data loaded", {
+      entriesFound: Object.keys(data).length,
+    });
 
     const entries: BlogEntry[] = [];
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,57 @@
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogContext {
+  readonly [key: string]: unknown;
+}
+
+export interface Logger {
+  readonly debug: (message: string, context?: LogContext) => void;
+  readonly info: (message: string, context?: LogContext) => void;
+  readonly warn: (message: string, context?: LogContext) => void;
+  readonly error: (message: string, context?: LogContext) => void;
+}
+
+function isDev(): boolean {
+  try {
+    return Boolean(import.meta.env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+function emit(
+  level: LogLevel,
+  scope: string,
+  message: string,
+  context?: LogContext,
+): void {
+  if ((level === "debug" || level === "info") && !isDev()) {
+    return;
+  }
+
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level,
+    scope,
+    message,
+    ...(context !== undefined ? { context } : {}),
+  };
+
+  if (level === "error") {
+    console.error(entry);
+  } else if (level === "warn") {
+    console.warn(entry);
+  } else {
+    // eslint-disable-next-line no-console
+    console.info(entry);
+  }
+}
+
+export function createLogger(scope: string): Logger {
+  return {
+    debug: (message, context) => emit("debug", scope, message, context),
+    info: (message, context) => emit("info", scope, message, context),
+    warn: (message, context) => emit("warn", scope, message, context),
+    error: (message, context) => emit("error", scope, message, context),
+  };
+}

--- a/src/pages/admin/agritech/index.astro
+++ b/src/pages/admin/agritech/index.astro
@@ -23,10 +23,6 @@ const firebaseConfig = {
   <script define:vars={{ firebaseConfig }}>
     // Make firebaseConfig globally available
     window.firebaseConfig = firebaseConfig;
-    console.log('=== FIREBASE CONFIG DEBUG ===');
-    console.log('firebaseConfig from define:vars:', firebaseConfig);
-    console.log('Database URL:', firebaseConfig.databaseURL);
-    console.log('===============================');
   </script>
   
   <!-- Tailwind CSS -->
@@ -156,16 +152,6 @@ const firebaseConfig = {
     const app = initializeApp(config);
     const auth = getAuth(app);
     const database = getDatabase(app, config.databaseURL);
-
-    console.log('Firebase initialized with modular API');
-    console.log('Config values being used:');
-    console.log('- API Key:', config.apiKey);
-    console.log('- Auth Domain:', config.authDomain);
-    console.log('- Database URL:', config.databaseURL);
-    console.log('- Project ID:', config.projectId);
-    console.log('App:', app);
-    console.log('Auth:', auth);
-    console.log('Database:', database);
 
     // DOM elements
     const loading = document.getElementById('loading');

--- a/src/pages/admin/news/index.astro
+++ b/src/pages/admin/news/index.astro
@@ -157,16 +157,6 @@ if (!firebaseConfig.apiKey || !firebaseConfig.authDomain) {
     const auth = getAuth(app);
     const database = getDatabase(app, config.databaseURL);
 
-    console.log('Firebase initialized with modular API');
-    console.log('Config values being used:');
-    console.log('- API Key:', config.apiKey);
-    console.log('- Auth Domain:', config.authDomain);
-    console.log('- Database URL:', config.databaseURL);
-    console.log('- Project ID:', config.projectId);
-    console.log('App:', app);
-    console.log('Auth:', auth);
-    console.log('Database:', database);
-
     // DOM elements
     const loading = document.getElementById('loading');
     const postsContainer = document.getElementById('posts-container');


### PR DESCRIPTION
Refs #39 (PR 4/4)

## 概要
コーディング規約(console.log 禁止)対応。構造化ロガーを導入し、console.log を全廃。

## 変更
- 新規 `src/lib/logger.ts` (57行): `createLogger(scope)` → `{debug, info, warn, error}`。構造化エントリ(timestamp/level/scope/message/context)、debug/info は DEV のみ出力(本番静音)、イミュータブル・依存ゼロ
- `src/lib/firebaseLoader.ts`: console.log 7件 → log.debug/info
- `src/components/agritech/EntryLayout.astro`: 1件 → log.warn(context付き)
- `src/pages/admin/agritech/index.astro`: 13件削除(**APIキーをconsoleにダンプする行を含む** — inline script のため logger 導入不可、デバッグノイズとして削除)
- `src/pages/admin/news/index.astro`: 9件削除(同上)
- `grep -rn "console\.log" src` 残存は `admin/agritech/edit.astro` のみ(#41 で除去済みのファイル。#41 マージで全体ゼロに)

## レビュー(code-reviewer + Codex 経路A)
- Codex: **CRITICAL/HIGH/MEDIUM/LOW 全てゼロ**。「変更はロギングのみ、Firebase初期化/DOM/CRUD/データマッピング不変」「logger設計・import境界とも問題なし」を確認
- code-reviewer(haiku)指摘の判断: (1) firebaseLoader のAPIキーfallback残存 → **本PRの差分外**(devに既存、#40 で一括対応) (2) isDev() のSSR非対応懸念 → Vite が import.meta.env を SSR でも置換するため誤検知(Codexも問題なしと確認) (3) console.error 残存 → 規約の禁止対象は console.log のみ、error は許容

## 検証
`npm run build` ✅ / `npx tsc --noEmit` エラー0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)